### PR TITLE
Java solution for Radix Sort using Stable Counting algorithm

### DIFF
--- a/RadixSort.java
+++ b/RadixSort.java
@@ -1,0 +1,64 @@
+package radixsort;
+
+public class RadixSort {
+    public static void main(String[] args)
+    {
+        int[] intArray = {4725, 4586, 1330, 8792, 1594, 5729};
+
+        System.out.println("Unsorted array:");
+        for (int i = 0; i < intArray.length ; i++)
+        {
+            System.out.print(intArray[i] + " ");
+        }
+        System.out.println();
+
+        radix_sort(intArray, 10, 4);
+
+        System.out.println("Radix sorted array:");
+
+        for (int i = 0; i < intArray.length ; i++)
+        {
+            System.out.print(intArray[i] + " ");
+        }
+    }
+
+    public static void radix_sort(int[] input, int radix, int width)
+    {
+        for(int i = 0; i < width; i++)
+        {
+            radix_single_sort(input, i, radix);
+        }
+    }
+
+    public static void radix_single_sort(int[] input, int position, int radix)
+    {
+        int len = input.length;
+        int[] counting_array = new int[radix];
+
+        for(int value : input)
+        {
+            counting_array[get_digit(value, position, radix)]++;
+        }
+
+        for(int j = 1; j < radix; j++)
+        {
+            counting_array[j] += counting_array[j-1];
+        }
+
+        int[] temp = new int[len];
+        for(int tmpIndex = len - 1; tmpIndex >= 0; tmpIndex--)
+        {
+            temp[--counting_array[get_digit(input[tmpIndex], position, radix)]] = input[tmpIndex];
+        }
+
+        for(int tmpIndex = 0; tmpIndex < len; tmpIndex++)
+        {
+            input[tmpIndex] = temp[tmpIndex];
+        }
+    }
+
+    public static int get_digit(int value, int position, int radix)
+    {
+        return value / (int) Math.pow(10, position) % radix;
+    }
+}


### PR DESCRIPTION
The lower bound for Comparison based sorting algorithm **(Merge Sort, Heap Sort, Quick-Sort .. etc) is Ω(nLogn)**, i.e., they cannot do better than **nLogn**. 

**Counting sort** is a linear time sorting algorithm that sort in **O(n+k)** time when elements are in the range from 1 to k.

What if the elements are in the range from 1 to n2? 
We can’t use counting sort because counting sort will take O(n2) which is worse than comparison-based sorting algorithms. Can we sort such an array in linear time? 

**Radix Sort** is the answer. The idea of **Radix Sort** is to do digit by digit sort starting from least significant digit to most significant digit. Radix sort uses counting sort as a subroutine to sort.

**The Radix Sort Algorithm** 

Do following for each digit i where i varies from least significant digit to the most significant digit.
Sort input array using counting sort (or any stable sort) according to the i’th digit.
Example:

Original, unsorted list:
170, 45, 75, 90, 802, 24, 2, 66

Sorting by least significant digit (1s place) gives: 
[*Notice that we keep 802 before 2, because 802 occurred 
before 2 in the original list, and similarly for pairs 
170 & 90 and 45 & 75.]

170, 90, 802, 2, 24, 45, 75, 66

Sorting by next digit (10s place) gives: 
[*Notice that 802 again comes before 2 as 802 comes before 
2 in the previous list.]

802, 2, 24, 45, 66, 170, 75, 90

Sorting by the most significant digit (100s place) gives:
2, 24, 45, 66, 75, 90, 170, 802

**Reference:** https://www.geeksforgeeks.org/radix-sort/